### PR TITLE
Close DB connection when underlining app throws an exception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,12 @@ module.exports = function(conn, options){
       return err;
     }
 
-    await next();
-    db.pool.end();
+		try {
+			await next();
+			db.pool.end();
+		}catch(err){
+			db.pool.end();
+			throw err;
+		}
   }
 }


### PR DESCRIPTION
Wrapper does not close connection when next() fails. Leaves many connections hanging open